### PR TITLE
Minor updates for 0.9.1 release

### DIFF
--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -20,7 +20,6 @@ This module contains an abstract base class for constructing AQT devices for Pen
 """
 import os
 import json
-import urllib
 from time import sleep
 
 import numpy as np
@@ -103,7 +102,7 @@ class AQTDevice(QubitDevice):
             raise ValueError("No valid api key for AQT platform found.")
         self.header = {"Ocp-Apim-Subscription-Key": self._api_key, "SDK": "pennylane"}
         self.data = {"access_token": self._api_key, "no_qubits": self.num_wires}
-        self.hostname = urllib.parse.urljoin("{}/".format(self.BASE_HOSTNAME), self.TARGET_PATH)
+        self.hostname = "/".join([self.BASE_HOSTNAME, self.TARGET_PATH])
 
     @property
     def retry_delay(self):

--- a/pennylane_aqt/device.py
+++ b/pennylane_aqt/device.py
@@ -77,7 +77,7 @@ class AQTDevice(QubitDevice):
     TARGET_PATH = ""
     HTTP_METHOD = "PUT"
 
-    def __init__(self, wires, shots=BASE_SHOTS, api_key=None, retry_delay=0.05):
+    def __init__(self, wires, shots=BASE_SHOTS, api_key=None, retry_delay=1):
         super().__init__(wires=wires, shots=shots, analytic=False)
         self.shots = shots
         self._retry_delay = retry_delay

--- a/pennylane_aqt/ops.py
+++ b/pennylane_aqt/ops.py
@@ -40,8 +40,7 @@ class R(Operation):
     num_params = 2
     num_wires = 1
     par_domain = "R"
-    grad_method = None
-    grad_recipe = None
+    grad_method = "A"
 
 
 class MS(Operation):
@@ -68,5 +67,4 @@ class MS(Operation):
     num_params = 1
     num_wires = 2
     par_domain = "R"
-    grad_method = None
-    grad_recipe = None
+    grad_method = "A"


### PR DESCRIPTION
- Both of the native gates have a grad recipe which fits the PennyLane default. [see here](https://www.aqt.eu/aqt-gate-definitions/)
- Lowered the retry timer so the plugin won't hammer the server for results
- removed an unnecessary import

@josh146 Should be good to go for a v0.9.1 release after this PR is merged